### PR TITLE
bump to version 0.41.1

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -66,7 +66,7 @@ jobs:
         curl --fail -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VER}/kustomize_${KUSTOMIZE_VER}_linux_amd64.tar.gz" -o kustomize.tar.gz
         os=$(go env GOOS)
         arch=$(go env GOARCH)
-        curl --fail -L "https://go.kubebuilder.io/dl/${KUBEBUILDER_VER}/${os}/${arch}" -o kubebuilder.tar.gz
+        curl --fail -L "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VER}/kubebuilder_${KUBEBUILDER_VER}_${os}_${arch}.tar.gz" -o kubebuilder.tar.gz
         curl --fail "https://www.foundationdb.org/downloads/${{ matrix.fdbver }}/ubuntu/installers/foundationdb-clients_${{ matrix.fdbver }}-1_amd64.deb" -o fdb.deb
         curl -Lo kind https://kind.sigs.k8s.io/dl/${KIND_VER}/kind-linux-amd64
         curl -Lo yq.tar.gz https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz

--- a/api/v1beta1/foundationdb_status_test.go
+++ b/api/v1beta1/foundationdb_status_test.go
@@ -68,7 +68,7 @@ var _ = Describe("FoundationDBStatus", func() {
 				},
 				Cluster: FoundationDBStatusClusterInfo{
 					DatabaseConfiguration: DatabaseConfiguration{
-						RedundancyMode: "double",
+						RedundancyMode: RedundancyModeDouble,
 						StorageEngine:  "ssd-2",
 						UsableRegions:  1,
 						Regions:        nil,
@@ -378,7 +378,7 @@ var _ = Describe("FoundationDBStatus", func() {
 				},
 				Cluster: FoundationDBStatusClusterInfo{
 					DatabaseConfiguration: DatabaseConfiguration{
-						RedundancyMode: "double",
+						RedundancyMode: RedundancyModeDouble,
 						StorageEngine:  "ssd-2",
 						UsableRegions:  1,
 						Regions:        nil,

--- a/api/v1beta1/foundationdb_version.go
+++ b/api/v1beta1/foundationdb_version.go
@@ -153,7 +153,7 @@ func (version FdbVersion) HasSidecarCrashOnEmpty() bool {
 // This is currently set to false across the board, pending investigation into
 // potential bugs with non-blocking excludes.
 func (version FdbVersion) HasNonBlockingExcludes() bool {
-	return version.IsAtLeast(FdbVersion{Major: 6, Minor: 3, Patch: 5})
+	return false
 }
 
 // NextMajorVersion returns the next major version of FoundationDB.

--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1358,9 +1358,9 @@ func (cluster *FoundationDBCluster) GetProcessCountsWithDefaults() (ProcessCount
 }
 
 // DesiredFaultTolerance returns the number of replicas we should be able to
-// lose when the cluster is at full replication health.
-func (cluster *FoundationDBCluster) DesiredFaultTolerance() int {
-	switch cluster.Spec.RedundancyMode {
+// lose given a redundancy mode.
+func DesiredFaultTolerance(redundancyMode RedundancyMode) int {
+	switch redundancyMode {
 	case RedundancyModeSingle:
 		return 0
 	case RedundancyModeDouble, RedundancyModeUnset:
@@ -1372,10 +1372,15 @@ func (cluster *FoundationDBCluster) DesiredFaultTolerance() int {
 	}
 }
 
-// MinimumFaultDomains returns the number of fault domains the cluster needs
-// to function.
-func (cluster *FoundationDBCluster) MinimumFaultDomains() int {
-	switch cluster.Spec.RedundancyMode {
+// DesiredFaultTolerance returns the number of replicas we should be able to
+// lose when the cluster is at full replication health.
+func (cluster *FoundationDBCluster) DesiredFaultTolerance() int {
+	return DesiredFaultTolerance(cluster.Spec.RedundancyMode)
+}
+
+// MinimumFaultDomains returns the number of fault domains given a redundancy mode.
+func MinimumFaultDomains(redundancyMode RedundancyMode) int {
+	switch redundancyMode {
 	case RedundancyModeSingle:
 		return 1
 	case RedundancyModeDouble, RedundancyModeUnset:
@@ -1385,6 +1390,12 @@ func (cluster *FoundationDBCluster) MinimumFaultDomains() int {
 	default:
 		return 1
 	}
+}
+
+// MinimumFaultDomains returns the number of fault domains the cluster needs
+// to function.
+func (cluster *FoundationDBCluster) MinimumFaultDomains() int {
+	return MinimumFaultDomains(cluster.Spec.RedundancyMode)
 }
 
 // DesiredCoordinatorCount returns the number of coordinators to recruit for

--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -1361,11 +1361,11 @@ func (cluster *FoundationDBCluster) GetProcessCountsWithDefaults() (ProcessCount
 // lose when the cluster is at full replication health.
 func (cluster *FoundationDBCluster) DesiredFaultTolerance() int {
 	switch cluster.Spec.RedundancyMode {
-	case "single":
+	case RedundancyModeSingle:
 		return 0
-	case "double", "":
+	case RedundancyModeDouble, RedundancyModeUnset:
 		return 1
-	case "triple":
+	case RedundancyModeTriple:
 		return 2
 	default:
 		return 0
@@ -1376,11 +1376,11 @@ func (cluster *FoundationDBCluster) DesiredFaultTolerance() int {
 // to function.
 func (cluster *FoundationDBCluster) MinimumFaultDomains() int {
 	switch cluster.Spec.RedundancyMode {
-	case "single":
+	case RedundancyModeSingle:
 		return 1
-	case "double", "":
+	case RedundancyModeDouble, RedundancyModeUnset:
 		return 2
-	case "triple":
+	case RedundancyModeTriple:
 		return 3
 	default:
 		return 1
@@ -1976,10 +1976,24 @@ type FoundationDBClusterFaultDomain struct {
 	ZoneIndex int `json:"zoneIndex,omitempty"`
 }
 
+// RedundancyMode defines the core replication factor for the database
+type RedundancyMode string
+
+const (
+	// RedundancyModeSingle defines the replication factor 1.
+	RedundancyModeSingle RedundancyMode = "single"
+	// RedundancyModeDouble defines the replication factor 2.
+	RedundancyModeDouble RedundancyMode = "double"
+	// RedundancyModeTriple defines the replication factor 3.
+	RedundancyModeTriple RedundancyMode = "triple"
+	// RedundancyModeUnset defines the replication factor unset.
+	RedundancyModeUnset RedundancyMode = ""
+)
+
 // DatabaseConfiguration represents the configuration of the database
 type DatabaseConfiguration struct {
 	// RedundancyMode defines the core replication factor for the database.
-	RedundancyMode string `json:"redundancy_mode,omitempty"`
+	RedundancyMode RedundancyMode `json:"redundancy_mode,omitempty"`
 
 	// StorageEngine defines the storage engine the database uses.
 	StorageEngine string `json:"storage_engine,omitempty"`
@@ -2346,8 +2360,8 @@ func (configuration DatabaseConfiguration) NormalizeConfiguration() DatabaseConf
 		result.UsableRegions = 1
 	}
 
-	if result.RedundancyMode == "" {
-		result.RedundancyMode = "double"
+	if result.RedundancyMode == RedundancyModeUnset {
+		result.RedundancyMode = RedundancyModeDouble
 	}
 
 	if result.StorageEngine == "" {

--- a/api/v1beta1/foundationdbcluster_types.go
+++ b/api/v1beta1/foundationdbcluster_types.go
@@ -468,7 +468,7 @@ func (processGroupStatus *ProcessGroupStatus) NeedsReplacement(failureTime int) 
 
 // AddAddresses adds the new address to the ProcessGroupStatus and removes duplicates and old addresses
 // if the process group is not marked as removal.
-func (processGroupStatus *ProcessGroupStatus) AddAddresses(addresses []string) {
+func (processGroupStatus *ProcessGroupStatus) AddAddresses(addresses []string, includeOldAddresses bool) {
 	newAddresses := make([]string, 0, len(addresses))
 	// Currently this only contains one address but might include in the future multiple addresses
 	// e.g. for dual stack
@@ -483,14 +483,12 @@ func (processGroupStatus *ProcessGroupStatus) AddAddresses(addresses []string) {
 
 	// If the newAddresses contains at least one IP address use this list as the new addresses
 	// and return
-	if len(newAddresses) > 0 && !processGroupStatus.Remove {
+	if len(newAddresses) > 0 && !includeOldAddresses {
 		processGroupStatus.Addresses = newAddresses
 		return
 	}
 
-	// The process group is marked for removal so we want to track all addresses during that removal
-	// to ensure we exclude and include all addresses during the removal process.
-	if processGroupStatus.Remove {
+	if includeOldAddresses {
 		processGroupStatus.Addresses = cleanAddressList(append(processGroupStatus.Addresses, newAddresses...))
 		return
 	}

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -48,7 +48,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				},
 				Spec: FoundationDBClusterSpec{
 					DatabaseConfiguration: DatabaseConfiguration{
-						RedundancyMode: "double",
+						RedundancyMode: RedundancyModeDouble,
 					},
 				},
 			}
@@ -143,7 +143,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				Spec: FoundationDBClusterSpec{
 					Version: Versions.Default.String(),
 					DatabaseConfiguration: DatabaseConfiguration{
-						RedundancyMode: "double",
+						RedundancyMode: RedundancyModeDouble,
 						RoleCounts: RoleCounts{
 							Storage:   5,
 							Logs:      3,
@@ -250,7 +250,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				Spec: FoundationDBClusterSpec{
 					Version: Versions.Default.String(),
 					DatabaseConfiguration: DatabaseConfiguration{
-						RedundancyMode: "double",
+						RedundancyMode: RedundancyModeDouble,
 						RoleCounts: RoleCounts{
 							Storage:   5,
 							Logs:      3,
@@ -305,7 +305,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				Spec: FoundationDBClusterSpec{
 					Version: Versions.Default.String(),
 					DatabaseConfiguration: DatabaseConfiguration{
-						RedundancyMode: "double",
+						RedundancyMode: RedundancyModeDouble,
 						RoleCounts: RoleCounts{
 							Storage:   5,
 							Logs:      3,
@@ -447,12 +447,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			Expect(cluster.MinimumFaultDomains()).To(Equal(2))
 			Expect(cluster.DesiredCoordinatorCount()).To(Equal(3))
 
-			cluster.Spec.RedundancyMode = "single"
+			cluster.Spec.RedundancyMode = RedundancyModeSingle
 			Expect(cluster.DesiredFaultTolerance()).To(Equal(0))
 			Expect(cluster.MinimumFaultDomains()).To(Equal(1))
 			Expect(cluster.DesiredCoordinatorCount()).To(Equal(1))
 
-			cluster.Spec.RedundancyMode = "double"
+			cluster.Spec.RedundancyMode = RedundancyModeDouble
 			Expect(cluster.DesiredFaultTolerance()).To(Equal(1))
 			Expect(cluster.MinimumFaultDomains()).To(Equal(2))
 			Expect(cluster.DesiredCoordinatorCount()).To(Equal(3))
@@ -579,7 +579,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 				},
 				Spec: FoundationDBClusterSpec{
 					DatabaseConfiguration: DatabaseConfiguration{
-						RedundancyMode: "double",
+						RedundancyMode: RedundancyModeDouble,
 						StorageEngine:  "ssd",
 						RoleCounts: RoleCounts{
 							Storage: 5,
@@ -591,7 +591,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			}
 
 			Expect(cluster.DesiredDatabaseConfiguration()).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				StorageEngine:  "ssd-2",
 				UsableRegions:  1,
 				RoleCounts: RoleCounts{
@@ -606,7 +606,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			cluster.Spec = FoundationDBClusterSpec{}
 
 			Expect(cluster.DesiredDatabaseConfiguration()).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				StorageEngine:  "ssd-2",
 				UsableRegions:  1,
 				RoleCounts: RoleCounts{
@@ -623,7 +623,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	When("getting the  configuration string", func() {
 		It("should be parsed correctly", func() {
 			configuration := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				StorageEngine:  "ssd",
 				UsableRegions:  1,
 				RoleCounts: RoleCounts{
@@ -651,14 +651,14 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	When("changing the redundancy mode", func() {
 		It("should return the new redundancy mode", func() {
 			currentConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 			}
 			finalConfig := DatabaseConfiguration{
-				RedundancyMode: "triple",
+				RedundancyMode: RedundancyModeTriple,
 			}
 			nextConfig := currentConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "triple",
+				RedundancyMode: RedundancyModeTriple,
 			}))
 		})
 	})
@@ -666,7 +666,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	When("enabling fearless DR", func() {
 		It("should return the new fearless config", func() {
 			currentConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -681,7 +681,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			}
 
 			finalConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -719,7 +719,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig := currentConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -758,7 +758,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -797,7 +797,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -839,12 +839,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	When("changing tto fearless dr without initial regions", func() {
 		It("should return the fearless config", func() {
 			currentConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 			}
 
 			finalConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -882,7 +882,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig := currentConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -921,7 +921,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -960,7 +960,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1002,12 +1002,12 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	When("enabling a single region without initial regions", func() {
 		It("should return the new redundancy mode", func() {
 			currentConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 			}
 
 			finalConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1023,7 +1023,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig := currentConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1043,7 +1043,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	When("disabling fearless DR", func() {
 		It("should return new configuration", func() {
 			currentConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1073,7 +1073,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			}
 
 			finalConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1089,7 +1089,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig := currentConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1114,7 +1114,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1139,7 +1139,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1159,7 +1159,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	When("disabling fearless DR and switch the dc", func() {
 		It("should return the new configuration", func() {
 			currentConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1196,7 +1196,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			}
 
 			finalConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1212,7 +1212,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig := currentConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1237,7 +1237,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1262,7 +1262,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1282,7 +1282,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	When("disabling and clearing regions", func() {
 		It("should return the new configuration", func() {
 			currentConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1312,13 +1312,13 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			}
 
 			finalConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 			}
 
 			nextConfig := currentConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1343,7 +1343,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1368,7 +1368,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 			}))
 			Expect(nextConfig).To(Equal(finalConfig))
@@ -1378,7 +1378,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	When("changing the primary DC with a single region", func() {
 		It("should return the new configuration", func() {
 			currentConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1393,7 +1393,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			}
 
 			finalConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1409,7 +1409,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig := currentConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1434,7 +1434,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1459,7 +1459,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1484,7 +1484,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1509,7 +1509,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1529,7 +1529,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	When("changing the primary DC with multiple regions", func() {
 		It("should return the new configuration", func() {
 			currentConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1552,7 +1552,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			}
 
 			finalConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1576,7 +1576,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig := currentConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1601,7 +1601,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1626,7 +1626,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1643,7 +1643,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1668,7 +1668,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1693,7 +1693,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1718,7 +1718,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1746,7 +1746,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 	When("changing multiple DCs", func() {
 		It("should return the new configuration", func() {
 			currentConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1769,7 +1769,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 			}
 
 			finalConfig := DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1793,7 +1793,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig := currentConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1818,7 +1818,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1843,7 +1843,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1860,7 +1860,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1885,7 +1885,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1910,7 +1910,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -1935,7 +1935,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1960,7 +1960,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -1977,7 +1977,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  1,
 				Regions: []Region{
 					{
@@ -2002,7 +2002,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -2027,7 +2027,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 
 			nextConfig = nextConfig.GetNextConfigurationChange(finalConfig)
 			Expect(nextConfig).To(Equal(DatabaseConfiguration{
-				RedundancyMode: "double",
+				RedundancyMode: RedundancyModeDouble,
 				UsableRegions:  2,
 				Regions: []Region{
 					{
@@ -2474,7 +2474,7 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 							NonTLS: true,
 						},
 						DatabaseConfiguration: DatabaseConfiguration{
-							RedundancyMode: "double",
+							RedundancyMode: RedundancyModeDouble,
 							StorageEngine:  "ssd-2",
 							UsableRegions:  1,
 							RoleCounts: RoleCounts{

--- a/api/v1beta1/foundationdbcluster_types_test.go
+++ b/api/v1beta1/foundationdbcluster_types_test.go
@@ -2873,12 +2873,13 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 		type testCase struct {
 			initialProcessGroup  ProcessGroupStatus
 			inputAddresses       []string
+			keepOldAddresses     bool
 			expectedProcessGroup ProcessGroupStatus
 		}
 
 		DescribeTable("should add or ignore the addresses",
 			func(tc testCase) {
-				tc.initialProcessGroup.AddAddresses(tc.inputAddresses)
+				tc.initialProcessGroup.AddAddresses(tc.inputAddresses, tc.keepOldAddresses)
 				Expect(tc.expectedProcessGroup).To(Equal(tc.initialProcessGroup))
 
 			},
@@ -2905,20 +2906,21 @@ var _ = Describe("[api] FoundationDBCluster", func() {
 						"2.2.2.2",
 					}},
 				}),
-			Entry("New Pod IP and process group is marked for removal",
+			Entry("New Pod IP and keep old addresses",
 				testCase{
 					initialProcessGroup: ProcessGroupStatus{
 						Addresses: []string{
 							"1.1.1.1",
 						},
-						Remove: true},
+					},
 					inputAddresses: []string{
 						"2.2.2.2",
 					},
+					keepOldAddresses: true,
 					expectedProcessGroup: ProcessGroupStatus{Addresses: []string{
 						"1.1.1.1",
 						"2.2.2.2",
-					}, Remove: true},
+					}},
 				}),
 		)
 	})

--- a/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0-beta.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: foundationdbbackups.apps.foundationdb.org
 spec:

--- a/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbbackups.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.0-beta.0
   creationTimestamp: null
   name: foundationdbbackups.apps.foundationdb.org
 spec:

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0-beta.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: foundationdbclusters.apps.foundationdb.org
 spec:

--- a/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbclusters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.0-beta.0
   creationTimestamp: null
   name: foundationdbclusters.apps.foundationdb.org
 spec:

--- a/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.6.0-beta.0
   creationTimestamp: null
   name: foundationdbrestores.apps.foundationdb.org
 spec:

--- a/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
+++ b/config/crd/bases/apps.foundationdb.org_foundationdbrestores.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0-beta.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: foundationdbrestores.apps.foundationdb.org
 spec:

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -129,7 +129,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: foundationdb/fdb-kubernetes-operator:v0.41.1
+        image: foundationdb/fdb-kubernetes-operator:v0.42.0
         name: manager
         ports:
         - containerPort: 8080

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -129,7 +129,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: foundationdb/fdb-kubernetes-operator:v0.42.0
+        image: foundationdb/fdb-kubernetes-operator:v0.42.1
         name: manager
         ports:
         - containerPort: 8080

--- a/config/samples/deployment/manager.yaml
+++ b/config/samples/deployment/manager.yaml
@@ -83,7 +83,7 @@ spec:
       containers:
       - command:
         - /manager
-        image: foundationdb/fdb-kubernetes-operator:v0.42.0
+        image: foundationdb/fdb-kubernetes-operator:v0.42.1
         name: manager
         env:
           - name: FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY

--- a/config/samples/deployment/manager.yaml
+++ b/config/samples/deployment/manager.yaml
@@ -83,7 +83,7 @@ spec:
       containers:
       - command:
         - /manager
-        image: foundationdb/fdb-kubernetes-operator:v0.41.1
+        image: foundationdb/fdb-kubernetes-operator:v0.42.0
         name: manager
         env:
           - name: FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -38,7 +38,7 @@ type AddPods struct{}
 // Reconcile runs the reconciler's work.
 func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
 	configMap, err := internal.GetConfigMap(cluster)
-	logger := log.WithValues("cluster", cluster.Name, "namespace", cluster.Namespace, "reconciler", "AddPods")
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "AddPods")
 	if err != nil {
 		return &Requeue{Error: err}
 	}
@@ -98,7 +98,7 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 				}
 				ip := service.Spec.ClusterIP
 				if ip == "" {
-					logger.Info("Service does not have an IP address", "podName", pod.Name)
+					logger.Info("Service does not have an IP address", "processGroupID", processGroup.ProcessGroupID)
 					return &Requeue{Message: fmt.Sprintf("Service %s does not have an IP address", service.Name)}
 				}
 				pod.Annotations[fdbtypes.PublicIPAnnotation] = ip

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -38,13 +38,14 @@ type AddPods struct{}
 // Reconcile runs the reconciler's work.
 func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
 	configMap, err := internal.GetConfigMap(cluster)
+	logger := log.WithValues("cluster", cluster.Name, "reconciler", "AddPods")
 	if err != nil {
 		return &Requeue{Error: err}
 	}
 	existingConfigMap := &corev1.ConfigMap{}
 	err = r.Get(context, types.NamespacedName{Namespace: configMap.Namespace, Name: configMap.Name}, existingConfigMap)
 	if err != nil && k8serrors.IsNotFound(err) {
-		log.Info("Creating config map", "namespace", configMap.Namespace, "cluster", cluster.Name, "name", configMap.Name)
+		logger.Info("Creating config map", "namespace", configMap.Namespace, "name", configMap.Name)
 		err = r.Create(context, configMap)
 		if err != nil {
 			return &Requeue{Error: err}
@@ -97,7 +98,7 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 				}
 				ip := service.Spec.ClusterIP
 				if ip == "" {
-					log.Info("Service does not have an IP address", "namespace", cluster.Namespace, "cluster", cluster.Name, "podName", pod.Name)
+					logger.Info("Service does not have an IP address", "namespace", cluster.Namespace, "podName", pod.Name)
 					return &Requeue{Message: fmt.Sprintf("Service %s does not have an IP address", service.Name)}
 				}
 				pod.Annotations[fdbtypes.PublicIPAnnotation] = ip

--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -38,14 +38,14 @@ type AddPods struct{}
 // Reconcile runs the reconciler's work.
 func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
 	configMap, err := internal.GetConfigMap(cluster)
-	logger := log.WithValues("cluster", cluster.Name, "reconciler", "AddPods")
+	logger := log.WithValues("cluster", cluster.Name, "namespace", cluster.Namespace, "reconciler", "AddPods")
 	if err != nil {
 		return &Requeue{Error: err}
 	}
 	existingConfigMap := &corev1.ConfigMap{}
 	err = r.Get(context, types.NamespacedName{Namespace: configMap.Namespace, Name: configMap.Name}, existingConfigMap)
 	if err != nil && k8serrors.IsNotFound(err) {
-		logger.Info("Creating config map", "namespace", configMap.Namespace, "name", configMap.Name)
+		logger.Info("Creating config map", "name", configMap.Name)
 		err = r.Create(context, configMap)
 		if err != nil {
 			return &Requeue{Error: err}
@@ -98,7 +98,7 @@ func (a AddPods) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context
 				}
 				ip := service.Spec.ClusterIP
 				if ip == "" {
-					logger.Info("Service does not have an IP address", "namespace", cluster.Namespace, "podName", pod.Name)
+					logger.Info("Service does not have an IP address", "podName", pod.Name)
 					return &Requeue{Message: fmt.Sprintf("Service %s does not have an IP address", service.Name)}
 				}
 				pod.Annotations[fdbtypes.PublicIPAnnotation] = ip

--- a/controllers/admin_client_test.go
+++ b/controllers/admin_client_test.go
@@ -65,7 +65,7 @@ var _ = Describe("admin_client_test", func() {
 		Context("with a basic cluster", func() {
 			It("should generate the status", func() {
 				Expect(status.Cluster.DatabaseConfiguration).To(Equal(fdbtypes.DatabaseConfiguration{
-					RedundancyMode: "double",
+					RedundancyMode: fdbtypes.RedundancyModeDouble,
 					StorageEngine:  "ssd-2",
 					UsableRegions:  1,
 					RoleCounts: fdbtypes.RoleCounts{

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -39,6 +39,7 @@ type BounceProcesses struct{}
 
 // Reconcile runs the reconciler's work.
 func (b BounceProcesses) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "BounceProcesses")
 	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
 	if err != nil {
 		return &Requeue{Error: err}
@@ -85,7 +86,7 @@ func (b BounceProcesses) Reconcile(r *FoundationDBClusterReconciler, context ctx
 		synced, err := r.updatePodDynamicConf(cluster, instances[0])
 		if !synced {
 			allSynced = false
-			log.Info("Update dynamic Pod config", "namespace", cluster.Namespace, "cluster", cluster.Name, "processGroupID", instanceID, "synced", synced, "error", err)
+			logger.Info("Update dynamic Pod config", "processGroupID", instanceID, "synced", synced, "error", err)
 		}
 	}
 
@@ -107,7 +108,7 @@ func (b BounceProcesses) Reconcile(r *FoundationDBClusterReconciler, context ctx
 			cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
 			err = r.Status().Update(context, cluster)
 			if err != nil {
-				log.Error(err, "Error updating cluster status", "namespace", cluster.Namespace, "cluster", cluster.Name)
+				logger.Error(err, "Error updating cluster status")
 			}
 
 			return &Requeue{Message: "Kills are disabled"}
@@ -119,7 +120,7 @@ func (b BounceProcesses) Reconcile(r *FoundationDBClusterReconciler, context ctx
 			cluster.Status.Generations.NeedsBounce = cluster.ObjectMeta.Generation
 			err = r.Status().Update(context, cluster)
 			if err != nil {
-				log.Error(err, "Error updating cluster status", "namespace", cluster.Namespace, "cluster", cluster.Name)
+				logger.Error(err, "Error updating cluster status")
 			}
 
 			// Retry after we waited the minimum uptime
@@ -169,7 +170,7 @@ func (b BounceProcesses) Reconcile(r *FoundationDBClusterReconciler, context ctx
 			}
 		}
 
-		log.Info("Bouncing instances", "namespace", cluster.Namespace, "cluster", cluster.Name, "addresses", addresses)
+		logger.Info("Bouncing instances", "addresses", addresses)
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "BouncingInstances", fmt.Sprintf("Bouncing processes: %v", addresses))
 		err = adminClient.KillInstances(addresses)
 		if err != nil {
@@ -191,6 +192,7 @@ func (b BounceProcesses) Reconcile(r *FoundationDBClusterReconciler, context ctx
 // getAddressesForUpgrade checks that all processes in a cluster are ready to be
 // upgraded and returns the full list of addresses.
 func getAddressesForUpgrade(r *FoundationDBClusterReconciler, adminClient AdminClient, lockClient LockClient, cluster *fdbtypes.FoundationDBCluster, version fdbtypes.FdbVersion) ([]fdbtypes.ProcessAddress, *Requeue) {
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "BounceProcesses")
 	pendingUpgrades, err := lockClient.GetPendingUpgrades(version)
 	if err != nil {
 		return nil, &Requeue{Error: err}
@@ -202,7 +204,7 @@ func getAddressesForUpgrade(r *FoundationDBClusterReconciler, adminClient AdminC
 	}
 
 	if !databaseStatus.Client.DatabaseStatus.Available {
-		log.Info("Deferring upgrade until database is available", "namespace", cluster.Namespace, "cluster", cluster.Name)
+		logger.Info("Deferring upgrade until database is available")
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpgradeRequeued", "Database is unavailable")
 		return nil, &Requeue{Message: "Deferring upgrade until database is available"}
 	}
@@ -218,7 +220,7 @@ func getAddressesForUpgrade(r *FoundationDBClusterReconciler, adminClient AdminC
 		}
 	}
 	if len(notReadyProcesses) > 0 {
-		log.Info("Deferring upgrade until all processes are ready to be upgraded", "namespace", cluster.Namespace, "cluster", cluster.Name, "remainingProcesses", notReadyProcesses)
+		logger.Info("Deferring upgrade until all processes are ready to be upgraded", "remainingProcesses", notReadyProcesses)
 		message := fmt.Sprintf("Waiting for processes to be updated: %v", notReadyProcesses)
 		r.Recorder.Event(cluster, corev1.EventTypeNormal, "UpgradeRequeued", message)
 		return nil, &Requeue{Message: message}

--- a/controllers/bounce_processes.go
+++ b/controllers/bounce_processes.go
@@ -215,6 +215,9 @@ func getAddressesForUpgrade(r *FoundationDBClusterReconciler, adminClient AdminC
 	addresses := make([]fdbtypes.ProcessAddress, 0, len(databaseStatus.Cluster.Processes))
 	for _, process := range databaseStatus.Cluster.Processes {
 		processID := process.Locality["instance_id"]
+		if process.Version == version.String() {
+			continue
+		}
 		if pendingUpgrades[processID] {
 			addresses = append(addresses, process.Address)
 		} else {

--- a/controllers/check_client_compatibility.go
+++ b/controllers/check_client_compatibility.go
@@ -37,6 +37,7 @@ type CheckClientCompatibility struct{}
 
 // Reconcile runs the reconciler's work.
 func (c CheckClientCompatibility) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "CheckClientCompatibility")
 	if !cluster.Status.Configured {
 		return nil
 	}
@@ -121,7 +122,7 @@ func (c CheckClientCompatibility) Reconcile(r *FoundationDBClusterReconciler, co
 				cluster.Spec.Version, strings.Join(unsupportedClients, ", "),
 			)
 			r.Recorder.Event(cluster, corev1.EventTypeNormal, "UnsupportedClient", message)
-			log.Info("Deferring reconciliation due to unsupported clients", "namespace", cluster.Namespace, "cluster", cluster.Name, "message", message)
+			logger.Info("Deferring reconciliation due to unsupported clients", "message", message)
 			return &Requeue{Message: message, Delay: 1 * time.Minute}
 		}
 	}

--- a/controllers/choose_removals.go
+++ b/controllers/choose_removals.go
@@ -34,6 +34,7 @@ type ChooseRemovals struct{}
 
 // Reconcile runs the reconciler's work.
 func (c ChooseRemovals) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "ChooseRemovals")
 	hasNewRemovals := false
 
 	var removals = make(map[string]bool)
@@ -90,9 +91,7 @@ func (c ChooseRemovals) Reconcile(r *FoundationDBClusterReconciler, context ctx.
 				return &Requeue{Error: err}
 			}
 
-			log.Info("Chose remaining processes after shrink",
-				"namespace", cluster.Namespace,
-				"cluster", cluster.Name,
+			logger.Info("Chose remaining processes after shrink",
 				"desiredCount", desiredCount,
 				"options", processClassLocality,
 				"selected", remainingProcesses)

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -194,7 +194,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			})
 
 			It("should fill in the required fields in the configuration", func() {
-				Expect(cluster.Status.DatabaseConfiguration.RedundancyMode).To(Equal("double"))
+				Expect(cluster.Status.DatabaseConfiguration.RedundancyMode).To(Equal(fdbtypes.RedundancyModeDouble))
 				Expect(cluster.Status.DatabaseConfiguration.StorageEngine).To(Equal("ssd-2"))
 				Expect(cluster.Status.ConnectionString).NotTo(Equal(""))
 			})
@@ -212,7 +212,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(adminClient).NotTo(BeNil())
-				Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal("double"))
+				Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal(fdbtypes.RedundancyModeDouble))
 				Expect(adminClient.DatabaseConfiguration.StorageEngine).To(Equal("ssd-2"))
 				Expect(adminClient.DatabaseConfiguration.RoleCounts).To(Equal(fdbtypes.RoleCounts{
 					Logs:       3,
@@ -1179,13 +1179,13 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 
 				status, err := adminClient.GetStatus()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(status.Cluster.DatabaseConfiguration.RedundancyMode).To(Equal("double"))
+				Expect(status.Cluster.DatabaseConfiguration.RedundancyMode).To(Equal(fdbtypes.RedundancyModeDouble))
 
-				cluster.Spec.DatabaseConfiguration.RedundancyMode = "triple"
+				cluster.Spec.DatabaseConfiguration.RedundancyMode = fdbtypes.RedundancyModeTriple
 
 				status, err = adminClient.GetStatus()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(status.Cluster.DatabaseConfiguration.RedundancyMode).To(Equal("double"))
+				Expect(status.Cluster.DatabaseConfiguration.RedundancyMode).To(Equal(fdbtypes.RedundancyModeDouble))
 			})
 
 			Context("with changes enabled", func() {
@@ -1195,28 +1195,28 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				})
 
 				It("should configure the database", func() {
-					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal("triple"))
+					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal(fdbtypes.RedundancyModeTriple))
 				})
 			})
 
 			Context("with a change to the log version", func() {
 				BeforeEach(func() {
 					cluster.Spec.DatabaseConfiguration.LogVersion = 3
-					cluster.Spec.DatabaseConfiguration.RedundancyMode = "double"
+					cluster.Spec.DatabaseConfiguration.RedundancyMode = fdbtypes.RedundancyModeDouble
 					generationGap = 1
 					err = k8sClient.Update(context.TODO(), cluster)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("should configure the database", func() {
-					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal("double"))
+					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal(fdbtypes.RedundancyModeDouble))
 					Expect(adminClient.DatabaseConfiguration.LogVersion).To(Equal(3))
 				})
 			})
 
 			Context("with a change to the log version that is not set in the spec", func() {
 				BeforeEach(func() {
-					cluster.Spec.DatabaseConfiguration.RedundancyMode = "double"
+					cluster.Spec.DatabaseConfiguration.RedundancyMode = fdbtypes.RedundancyModeDouble
 					cluster.Spec.SeedConnectionString = "touch"
 
 					configuration := cluster.DesiredDatabaseConfiguration()
@@ -1239,7 +1239,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 					shouldCompleteReconciliation = false
 					var flag = false
 					cluster.Spec.AutomationOptions.ConfigureDatabase = &flag
-					cluster.Spec.DatabaseConfiguration.RedundancyMode = "triple"
+					cluster.Spec.DatabaseConfiguration.RedundancyMode = fdbtypes.RedundancyModeTriple
 
 					err = k8sClient.Update(context.TODO(), cluster)
 					Expect(err).NotTo(HaveOccurred())
@@ -1259,7 +1259,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 					adminClient, err := newMockAdminClientUncast(cluster, k8sClient)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal("double"))
+					Expect(adminClient.DatabaseConfiguration.RedundancyMode).To(Equal(fdbtypes.RedundancyModeDouble))
 				})
 			})
 		})

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -1717,67 +1717,6 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			})
 		})
 
-		Context("with a change to environment variables with the deprecated field", func() {
-			BeforeEach(func() {
-				cluster.Spec.MainContainer.Env = append(cluster.Spec.MainContainer.Env, corev1.EnvVar{
-					Name:  "TEST_CHANGE",
-					Value: "1",
-				})
-			})
-
-			Context("with deletion enabled", func() {
-				BeforeEach(func() {
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("should set the environment variable on the pods", func() {
-					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
-
-					for _, pod := range pods.Items {
-						Expect(len(pod.Spec.Containers[0].Env)).To(Equal(2))
-						Expect(pod.Spec.Containers[0].Env[0].Name).To(Equal("TEST_CHANGE"))
-						Expect(pod.Spec.Containers[0].Env[0].Value).To(Equal("1"))
-					}
-				})
-			})
-
-			Context("with deletion disabled", func() {
-				BeforeEach(func() {
-					var flag = false
-					cluster.Spec.AutomationOptions.DeletePods = &flag
-
-					shouldCompleteReconciliation = false
-
-					err = k8sClient.Update(context.TODO(), cluster)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				JustBeforeEach(func() {
-					generations, err := reloadClusterGenerations(cluster)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(generations).To(Equal(fdbtypes.ClusterGenerationStatus{
-						Reconciled:          originalVersion,
-						NeedsPodDeletion:    originalVersion + 1,
-						HasUnhealthyProcess: originalVersion + 1,
-					}))
-				})
-
-				It("should not set the environment variable on the pods", func() {
-					pods := &corev1.PodList{}
-					err = k8sClient.List(context.TODO(), pods, getListOptions(cluster)...)
-					Expect(err).NotTo(HaveOccurred())
-
-					for _, pod := range pods.Items {
-						Expect(len(pod.Spec.Containers[0].Env)).To(Equal(1))
-						Expect(pod.Spec.Containers[0].Env[0].Name).To(Equal("FDB_CLUSTER_FILE"))
-					}
-				})
-			})
-		})
-
 		Context("with a change to the public IP source", func() {
 			BeforeEach(func() {
 				source := fdbtypes.PublicIPSourceService

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -952,7 +952,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 			})
 		})
 
-		Context("with a missing process and pending exclusion", func() {
+		Context("with missing processes and pending exclusion", func() {
 			var adminClient *MockAdminClient
 
 			BeforeEach(func() {
@@ -966,6 +966,7 @@ var _ = Describe(string(fdbtypes.ProcessClassClusterController), func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				adminClient.MockMissingProcessGroup("storage-2", true)
+				adminClient.MockMissingProcessGroup("storage-3", true)
 				shouldCompleteReconciliation = false
 				generationGap = 0
 			})

--- a/controllers/exclude_instances.go
+++ b/controllers/exclude_instances.go
@@ -23,12 +23,18 @@ package controllers
 import (
 	ctx "context"
 	"fmt"
+	"math"
 	"net"
 
 	corev1 "k8s.io/api/core/v1"
 
 	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
 )
+
+// The fraction of processes that must be present in order to start a new
+// exclusion.
+var missingProcessThreshold = 0.8
 
 // ExcludeInstances provides a reconciliation step for excluding instances from
 // the database.
@@ -36,8 +42,6 @@ type ExcludeInstances struct{}
 
 // Reconcile runs the reconciler's work.
 func (e ExcludeInstances) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
-	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "ExcludeInstances")
-
 	adminClient, err := r.getDatabaseClientProvider().GetAdminClient(cluster, r)
 	if err != nil {
 		return &Requeue{Error: err}
@@ -52,6 +56,7 @@ func (e ExcludeInstances) Reconcile(r *FoundationDBClusterReconciler, context ct
 	}
 
 	addresses := make([]fdbtypes.ProcessAddress, 0, removalCount)
+	processClassesToExclude := make(map[fdbtypes.ProcessClass]internal.None)
 	if removalCount > 0 {
 		exclusions, err := adminClient.GetExclusions()
 		if err != nil {
@@ -67,28 +72,18 @@ func (e ExcludeInstances) Reconcile(r *FoundationDBClusterReconciler, context ct
 			for _, address := range processGroup.Addresses {
 				if processGroup.Remove && !processGroup.ExclusionSkipped && !currentExclusionMap[address] {
 					addresses = append(addresses, fdbtypes.ProcessAddress{IPAddress: net.ParseIP(address)})
+					processClassesToExclude[processGroup.ProcessClass] = internal.None{}
 				}
 			}
 		}
 	}
 
 	if len(addresses) > 0 {
-		// Block excludes on missing processes not marked for removal
-		missingProcesses := make([]string, 0)
-		for _, processGroupStatus := range cluster.Status.ProcessGroups {
-			if processGroupStatus.Remove {
-				continue
+		for processClass := range processClassesToExclude {
+			canExclude, missingProcesses := canExcludeNewInstances(cluster, processClass)
+			if !canExclude {
+				return &Requeue{Message: fmt.Sprintf("Waiting for missing processes: %v. Addresses to exclude: %v", missingProcesses, addresses)}
 			}
-
-			// TODO(johscheuer): we should add here a threshold for how many missing processes are fine
-			if processGroupStatus.GetConditionTime(fdbtypes.MissingProcesses) != nil ||
-				processGroupStatus.GetConditionTime(fdbtypes.MissingPod) != nil {
-				missingProcesses = append(missingProcesses, processGroupStatus.ProcessGroupID)
-				logger.Info("Missing processes", "processGroupID", processGroupStatus.ProcessGroupID)
-			}
-		}
-		if len(missingProcesses) > 0 {
-			return &Requeue{Message: fmt.Sprintf("Waiting for missing processes: %v", missingProcesses)}
 		}
 
 		hasLock, err := r.takeLock(cluster, fmt.Sprintf("excluding instances: %v", addresses))
@@ -105,4 +100,38 @@ func (e ExcludeInstances) Reconcile(r *FoundationDBClusterReconciler, context ct
 	}
 
 	return nil
+}
+
+func canExcludeNewInstances(cluster *fdbtypes.FoundationDBCluster, processClass fdbtypes.ProcessClass) (bool, []string) {
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "ExcludeInstances")
+
+	// Block excludes on missing processes not marked for removal
+	missingProcesses := make([]string, 0)
+	validProcesses := make([]string, 0)
+
+	for _, processGroupStatus := range cluster.Status.ProcessGroups {
+		if processGroupStatus.Remove || processGroupStatus.ProcessClass != processClass {
+			continue
+		}
+
+		if processGroupStatus.GetConditionTime(fdbtypes.MissingProcesses) != nil ||
+			processGroupStatus.GetConditionTime(fdbtypes.MissingPod) != nil {
+			missingProcesses = append(missingProcesses, processGroupStatus.ProcessGroupID)
+			logger.Info("Missing processes", "processGroupID", processGroupStatus.ProcessGroupID)
+		} else {
+			validProcesses = append(validProcesses, processGroupStatus.ProcessGroupID)
+		}
+	}
+
+	desiredProcesses, err := cluster.GetProcessCountsWithDefaults()
+	if err != nil {
+		logger.Error(err, "Error calculating process counts")
+		return false, missingProcesses
+	}
+	desiredCount := desiredProcesses.Map()[processClass]
+
+	if len(validProcesses) < desiredCount-1 && len(validProcesses) < int(math.Ceil(float64(desiredCount)*missingProcessThreshold)) {
+		return false, missingProcesses
+	}
+	return true, nil
 }

--- a/controllers/exclude_instances_test.go
+++ b/controllers/exclude_instances_test.go
@@ -1,0 +1,151 @@
+/*
+ * exclude_instances_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
+
+	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("exclude_instances", func() {
+	var cluster *fdbtypes.FoundationDBCluster
+	var err error
+
+	BeforeEach(func() {
+		cluster = internal.CreateDefaultCluster()
+		err = k8sClient.Create(context.TODO(), cluster)
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err := reconcileCluster(cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Requeue).To(BeFalse())
+
+		generation, err := reloadCluster(cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(generation).To(Equal(int64(1)))
+	})
+
+	Describe("canExcludeNewInstances", func() {
+		Context("with a small cluster", func() {
+			When("all processes are healthy", func() {
+				It("should allow the exclusion", func() {
+					canExclude, missing := canExcludeNewInstances(cluster, fdbtypes.ProcessClassStorage)
+					Expect(canExclude).To(BeTrue())
+					Expect(missing).To(BeNil())
+				})
+			})
+
+			When("one process group is missing", func() {
+				BeforeEach(func() {
+					createMissingProcesses(cluster, 1, fdbtypes.ProcessClassStorage)
+				})
+
+				It("should allow the exclusion", func() {
+					canExclude, missing := canExcludeNewInstances(cluster, fdbtypes.ProcessClassStorage)
+					Expect(canExclude).To(BeTrue())
+					Expect(missing).To(BeNil())
+				})
+			})
+
+			When("two process groups are missing", func() {
+				BeforeEach(func() {
+					createMissingProcesses(cluster, 2, fdbtypes.ProcessClassStorage)
+				})
+
+				It("should not allow the exclusion", func() {
+					canExclude, missing := canExcludeNewInstances(cluster, fdbtypes.ProcessClassStorage)
+					Expect(canExclude).To(BeFalse())
+					Expect(missing).To(Equal([]string{"storage-1", "storage-2"}))
+				})
+			})
+
+			When("two process groups of a different type are missing", func() {
+				BeforeEach(func() {
+					createMissingProcesses(cluster, 2, fdbtypes.ProcessClassLog)
+				})
+
+				It("should allow the exclusion", func() {
+					canExclude, missing := canExcludeNewInstances(cluster, fdbtypes.ProcessClassStorage)
+					Expect(canExclude).To(BeTrue())
+					Expect(missing).To(BeNil())
+				})
+			})
+		})
+
+		Context("with a large cluster", func() {
+			BeforeEach(func() {
+				cluster.Spec.ProcessCounts.Storage = 20
+				err = clusterReconciler.Update(context.TODO(), cluster)
+				Expect(err).NotTo(HaveOccurred())
+
+				result, err := reconcileCluster(cluster)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Requeue).To(BeFalse())
+
+				_, err = reloadCluster(cluster)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			When("two process groups are missing", func() {
+				BeforeEach(func() {
+					createMissingProcesses(cluster, 2, fdbtypes.ProcessClassStorage)
+				})
+
+				It("should allow the exclusion", func() {
+					canExclude, missing := canExcludeNewInstances(cluster, fdbtypes.ProcessClassStorage)
+					Expect(canExclude).To(BeTrue())
+					Expect(missing).To(BeNil())
+				})
+			})
+
+			When("five process groups are missing", func() {
+				BeforeEach(func() {
+					createMissingProcesses(cluster, 5, fdbtypes.ProcessClassStorage)
+				})
+
+				It("should not allow the exclusion", func() {
+					canExclude, missing := canExcludeNewInstances(cluster, fdbtypes.ProcessClassStorage)
+					Expect(canExclude).To(BeFalse())
+					Expect(missing).To(Equal([]string{"storage-1", "storage-10", "storage-11", "storage-12", "storage-13"}))
+				})
+			})
+		})
+	})
+})
+
+func createMissingProcesses(cluster *fdbtypes.FoundationDBCluster, count int, processClass fdbtypes.ProcessClass) {
+	missing := 0
+	for _, processGroup := range cluster.Status.ProcessGroups {
+		if processGroup.ProcessClass == processClass {
+			processGroup.UpdateCondition(fdbtypes.MissingProcesses, true, nil, "")
+			missing++
+			if missing == count {
+				break
+			}
+		}
+	}
+	Expect(missing).To(Equal(count))
+}

--- a/controllers/generate_initial_cluster_file.go
+++ b/controllers/generate_initial_cluster_file.go
@@ -37,11 +37,12 @@ type GenerateInitialClusterFile struct{}
 
 // Reconcile runs the reconciler's work.
 func (g GenerateInitialClusterFile) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "GenerateInitialClusterFile")
 	if cluster.Status.ConnectionString != "" {
 		return nil
 	}
 
-	log.Info("Generating initial cluster file", "namespace", cluster.Namespace, "cluster", cluster.Name)
+	logger.Info("Generating initial cluster file")
 	r.Recorder.Event(cluster, corev1.EventTypeNormal, "ChangingCoordinators", "Choosing initial coordinators")
 	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, fdbtypes.ProcessClassStorage, "")...)
 	if err != nil {

--- a/controllers/replace_failed_pods.go
+++ b/controllers/replace_failed_pods.go
@@ -49,6 +49,7 @@ func (c ReplaceFailedPods) Reconcile(r *FoundationDBClusterReconciler, context c
 // chooseNewRemovals flags failed processes for removal and returns an indicator
 // of whether any processes were thus flagged.
 func chooseNewRemovals(cluster *fdbtypes.FoundationDBCluster) bool {
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "ReplaceFailedPods")
 	if !*cluster.Spec.AutomationOptions.Replacements.Enabled {
 		return false
 	}
@@ -84,9 +85,7 @@ func chooseNewRemovals(cluster *fdbtypes.FoundationDBCluster) bool {
 				continue
 			}
 
-			log.Info("Replace instance",
-				"namespace", cluster.Namespace,
-				"cluster", cluster.Name,
+			logger.Info("Replace instance",
 				"processGroupID", processGroupStatus.ProcessGroupID,
 				"reason", fmt.Sprintf("automatic replacement detected failure time: %s", time.Unix(missingTime, 0).UTC().String()))
 

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -56,7 +56,7 @@ func (u UpdateSidecarVersions) Reconcile(r *FoundationDBClusterReconciler, conte
 
 		for containerIndex, container := range instance.Pod.Spec.Containers {
 			if container.Name == "foundationdb-kubernetes-sidecar" && container.Image != image {
-				logger.Info("Upgrading sidecar", "pod", instance.Pod.Name, "oldImage", container.Image, "newImage", image)
+				logger.Info("Upgrading sidecar", "processGroupID", instance.GetInstanceID(), "oldImage", container.Image, "newImage", image)
 				err = r.PodLifecycleManager.UpdateImageVersion(r, context, cluster, instance, containerIndex, image)
 				if err != nil {
 					return &Requeue{Error: err}

--- a/controllers/update_sidecar_versions.go
+++ b/controllers/update_sidecar_versions.go
@@ -38,6 +38,7 @@ type UpdateSidecarVersions struct {
 
 // Reconcile runs the reconciler's work.
 func (u UpdateSidecarVersions) Reconcile(r *FoundationDBClusterReconciler, context ctx.Context, cluster *fdbtypes.FoundationDBCluster) *Requeue {
+	logger := log.WithValues("namespace", cluster.Namespace, "cluster", cluster.Name, "reconciler", "UpdateSidecarVersions")
 	instances, err := r.PodLifecycleManager.GetInstances(r, cluster, context, internal.GetPodListOptions(cluster, "", "")...)
 	if err != nil {
 		return &Requeue{Error: err}
@@ -55,7 +56,7 @@ func (u UpdateSidecarVersions) Reconcile(r *FoundationDBClusterReconciler, conte
 
 		for containerIndex, container := range instance.Pod.Spec.Containers {
 			if container.Name == "foundationdb-kubernetes-sidecar" && container.Image != image {
-				log.Info("Upgrading sidecar", "namespace", cluster.Namespace, "cluster", cluster.Name, "pod", instance.Pod.Name, "oldImage", container.Image, "newImage", image)
+				logger.Info("Upgrading sidecar", "pod", instance.Pod.Name, "oldImage", container.Image, "newImage", image)
 				err = r.PodLifecycleManager.UpdateImageVersion(r, context, cluster, instance, containerIndex, image)
 				if err != nil {
 					return &Requeue{Error: err}

--- a/docs/changelog/v0.41.0.md
+++ b/docs/changelog/v0.41.0.md
@@ -1,4 +1,4 @@
-# v0.41.1
+# v0.41.0
 
 * Fix the security context and ClusterRoleBindings in the helm chart.
 * Fix some scenarios where we block reconciliation on pending pods.

--- a/docs/changelog/v0.42.0.md
+++ b/docs/changelog/v0.42.0.md
@@ -1,0 +1,10 @@
+# v0.42.0
+
+* Adds a command to fix coordinator IPs when cluster is unavailable.
+* Change the kubebuilder download path in the PR build.
+* Allow exclusions when another process is missing.
+* Replace pods with the PodFailing condition.
+* Skip already upgraded processes.
+* Printout pod names instead of a pod struct.
+* Adds a log field reconciler.
+* Minor refactoring.

--- a/docs/changelog/v0.42.1.md
+++ b/docs/changelog/v0.42.1.md
@@ -1,0 +1,4 @@
+# v0.42.1
+
+* Disable non-blocking excludes.
+* Change kubebuilder download path in PR build.

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -158,7 +158,7 @@ DatabaseConfiguration represents the configuration of the database
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| redundancy_mode | RedundancyMode defines the core replication factor for the database. | string | false |
+| redundancy_mode | RedundancyMode defines the core replication factor for the database. | RedundancyMode | false |
 | storage_engine | StorageEngine defines the storage engine the database uses. | string | false |
 | usable_regions | UsableRegions defines how many regions the database should store data in. | int | false |
 | regions | Regions defines the regions that the database can replicate in. | [][Region](#region) | false |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -25,7 +25,7 @@ published for each major version.
 
 | Operator Version  | Most Recent Version | Supported Cluster Models  | Supported FDB Versions  | Supported Kubernetes Versions |
 | ----------------- | ------------------- | ------------------------- | ----------------------- | ----------------------------- |
-| 0.x               | 0.42.0              | v1beta1                   | 6.1.12+                 | 1.15.0+                       |
+| 0.x               | 0.42.1              | v1beta1                   | 6.1.12+                 | 1.15.0+                       |
 
 ## Preparing for a Major Release
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -25,7 +25,7 @@ published for each major version.
 
 | Operator Version  | Most Recent Version | Supported Cluster Models  | Supported FDB Versions  | Supported Kubernetes Versions |
 | ----------------- | ------------------- | ------------------------- | ----------------------- | ----------------------------- |
-| 0.x               | 0.41.1              | v1beta1                   | 6.1.12+                 | 1.15.0+                       |
+| 0.x               | 0.42.0              | v1beta1                   | 6.1.12+                 | 1.15.0+                       |
 
 ## Preparing for a Major Release
 

--- a/docs/manual/replacements_and_deletions.md
+++ b/docs/manual/replacements_and_deletions.md
@@ -22,7 +22,10 @@ The operator has an option to automatically replace pods that are in a bad state
 * The process group has a condition that is eligible for replacement, and has been in that condition for 1800 seconds. This time window is configurable through `automationOptions.replacements.failureDetectionTimeSeconds`.
 * The number of process groups that are marked for removal and not fully excluded, counting the process group that is being evaluated for replacement, is less than or equal to 1. This limit is configurable through `automationOptions.replacements.maxConcurrentReplacements`.
 
-The only condition that is currently eligible for replacement is when the process is not reporting to the database.
+The following conditions are currently eligible for replacement:
+
+* `MissingProcesses`: This indicates that a process is not reporting to the database.
+* `PodFailing`: This indicates that one of the containers is not ready.
 
 ## Next
 

--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -132,7 +132,7 @@ var _ = Describe("[e2e] cluster tests", func() {
 						Key: "foundationdb.org/none",
 					},
 					DatabaseConfiguration: fdbtypes.DatabaseConfiguration{
-						RedundancyMode: "single",
+						RedundancyMode: fdbtypes.RedundancyModeSingle,
 					},
 					ProcessCounts: fdbtypes.ProcessCounts{
 						Storage:           1,

--- a/fdbclient/admin_client.go
+++ b/fdbclient/admin_client.go
@@ -419,7 +419,7 @@ func (client *cliAdminClient) VersionSupported(versionString string) (bool, erro
 	_, err = os.Stat(getBinaryPath("fdbcli", versionString))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return false, nil
+			return false, err
 		}
 		return false, err
 	}

--- a/helm/fdb-operator/Chart.yaml
+++ b/helm/fdb-operator/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.40.0
+appVersion: 0.42.0

--- a/helm/fdb-operator/Chart.yaml
+++ b/helm/fdb-operator/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.42.0
+appVersion: 0.42.1

--- a/helm/fdb-operator/values.yaml
+++ b/helm/fdb-operator/values.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   repository: foundationdb/fdb-kubernetes-operator
-  tag: v0.42.0
+  tag: v0.42.1
   pullPolicy: IfNotPresent
 
 initContainers:

--- a/helm/fdb-operator/values.yaml
+++ b/helm/fdb-operator/values.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   repository: foundationdb/fdb-kubernetes-operator
-  tag: v0.40.0
+  tag: v0.42.0
   pullPolicy: IfNotPresent
 
 initContainers:

--- a/internal/pod_models.go
+++ b/internal/pod_models.go
@@ -236,15 +236,11 @@ func GetPodSpec(cluster *fdbtypes.FoundationDBCluster, processClass fdbtypes.Pro
 		mainContainer.SecurityContext.ReadOnlyRootFilesystem = &readOnlyRootFilesystem
 	}
 
-	customizeContainer(mainContainer, cluster.Spec.MainContainer)
-
-	customizeContainer(initContainer, cluster.Spec.SidecarContainer)
 	err = configureSidecarContainerForCluster(cluster, initContainer, true, instanceID, processSettings.GetAllowTagOverride())
 	if err != nil {
 		return nil, err
 	}
 
-	customizeContainer(sidecarContainer, cluster.Spec.SidecarContainer)
 	err = configureSidecarContainerForCluster(cluster, sidecarContainer, false, instanceID, processSettings.GetAllowTagOverride())
 	if err != nil {
 		return nil, err
@@ -690,34 +686,6 @@ func extendEnv(container *corev1.Container, env ...corev1.EnvVar) {
 		if !existingVars[envVar.Name] {
 			container.Env = append(container.Env, envVar)
 		}
-	}
-}
-
-// customizeContainer adds container overrides from the cluster spec to a
-// container.
-func customizeContainer(container *corev1.Container, overrides fdbtypes.ContainerOverrides) {
-	envOverrides := make(map[string]bool)
-
-	fullEnv := make([]corev1.EnvVar, 0)
-	for _, envVar := range overrides.Env {
-		fullEnv = append(fullEnv, *envVar.DeepCopy())
-		envOverrides[envVar.Name] = true
-	}
-
-	for _, envVar := range container.Env {
-		if !envOverrides[envVar.Name] {
-			fullEnv = append(fullEnv, envVar)
-		}
-	}
-
-	container.Env = fullEnv
-
-	for _, volume := range overrides.VolumeMounts {
-		container.VolumeMounts = append(container.VolumeMounts, *volume.DeepCopy())
-	}
-
-	if overrides.SecurityContext != nil {
-		container.SecurityContext = overrides.SecurityContext
 	}
 }
 

--- a/kubectl-fdb/cmd/analyze.go
+++ b/kubectl-fdb/cmd/analyze.go
@@ -341,7 +341,12 @@ func analyzeCluster(cmd *cobra.Command, kubeClient client.Client, clusterName st
 
 		pods := filterDeletePods(replaceInstances, killPods)
 		if !force && len(pods) > 0 {
-			confirmed = confirmAction(fmt.Sprintf("Delete Pods %v in cluster %s/%s", killPods, namespace, clusterName))
+			podNames := make([]string, 0, len(killPods))
+			for _, pod := range killPods {
+				podNames = append(podNames, pod.Name)
+			}
+
+			confirmed = confirmAction(fmt.Sprintf("Delete Pods %v in cluster %s/%s", strings.Join(podNames, ","), namespace, clusterName))
 		}
 
 		if force || confirmed {

--- a/kubectl-fdb/cmd/fix_coordinator_ips.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips.go
@@ -216,9 +216,8 @@ func runFixCoordinatorIPs(kubeClient client.Client, cluster *fdbtypes.Foundation
 		return err
 	}
 
-	logger := log.Default()
 	if dryRun {
-		logger.Printf("New connection string: %s", cluster.Status.ConnectionString)
+		log.Printf("New connection string: %s", cluster.Status.ConnectionString)
 	}
 
 	commands, err := buildClusterFileUpdateCommands(cluster, kubeClient, context, namespace)
@@ -227,11 +226,11 @@ func runFixCoordinatorIPs(kubeClient client.Client, cluster *fdbtypes.Foundation
 	}
 	for _, command := range commands {
 		if dryRun {
-			logger.Printf("Update command: %s", strings.Join(command.Args, " "))
+			log.Printf("Update command: %s", strings.Join(command.Args, " "))
 		} else {
 			err := command.Run()
 			if err != nil {
-				logger.Print(err.Error())
+				log.Print(err.Error())
 			}
 		}
 	}

--- a/kubectl-fdb/cmd/fix_coordinator_ips.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips.go
@@ -1,0 +1,247 @@
+/*
+ * fix_coordinator_ips.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	ctx "context"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
+)
+
+func newFixCoordinatorIPsCmd(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newFDBOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:   "fix-coordinator-ips",
+		Short: "Update the coordinator IPs in the cluster file",
+		Long:  "Update the coordinator IPs in the cluster file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clusterName, err := cmd.Flags().GetString("fdb-cluster")
+			if err != nil {
+				return err
+			}
+
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				return err
+			}
+
+			config, err := o.configFlags.ToRESTConfig()
+			if err != nil {
+				return err
+			}
+
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = fdbtypes.AddToScheme(scheme)
+
+			kubeClient, err := client.New(config, client.Options{Scheme: scheme})
+			if err != nil {
+				return err
+			}
+
+			namespace, err := getNamespace(*o.configFlags.Namespace)
+			if err != nil {
+				return err
+			}
+
+			cluster, err := loadCluster(kubeClient, namespace, clusterName)
+			if err != nil {
+				return err
+			}
+
+			err = runFixCoordinatorIPs(kubeClient, cluster, *o.configFlags.Context, namespace, dryRun)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Example: `
+  # Update the coordinator IPs for the cluster
+  kubectl fdb fix-coordinator-ips -c cluster
+  `,
+	}
+
+	cmd.Flags().StringP("fdb-cluster", "c", "", "update the provided cluster.")
+	err := cmd.MarkFlagRequired("fdb-cluster")
+	cmd.Flags().Bool("dry-run", false, "Print the new connection string without updating it")
+	if err != nil {
+		log.Fatal(err)
+	}
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
+	cmd.SetIn(o.In)
+
+	o.configFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// buildClusterFileUpdateCommands generates commands for using kubectl exec to
+// update the cluster file in the pods for a cluster.
+func buildClusterFileUpdateCommands(cluster *fdbtypes.FoundationDBCluster, kubeClient client.Client, context string, namespace string) ([]exec.Cmd, error) {
+	pods := &corev1.PodList{}
+
+	selector := labels.NewSelector()
+
+	err := internal.NormalizeClusterSpec(cluster, internal.DeprecationOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for key, value := range cluster.Spec.LabelConfig.MatchLabels {
+		requirement, err := labels.NewRequirement(key, selection.Equals, []string{value})
+		if err != nil {
+			return nil, err
+		}
+		selector = selector.Add(*requirement)
+	}
+
+	processClassRequirement, err := labels.NewRequirement(fdbtypes.FDBProcessClassLabel, selection.Exists, nil)
+	if err != nil {
+		return nil, err
+	}
+	selector = selector.Add(*processClassRequirement)
+
+	err = kubeClient.List(ctx.Background(), pods,
+		client.InNamespace(namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+		client.MatchingFields{"status.phase": "Running"},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	kubectlPath, err := exec.LookPath("kubectl")
+	if err != nil {
+		return nil, err
+	}
+
+	baseArgs := []string{kubectlPath, "--namespace", namespace}
+	if context != "" {
+		baseArgs = append(baseArgs, "--context", context)
+	}
+	baseArgs = append(baseArgs, "exec", "-it", "-c", "foundationdb")
+
+	execArgs := []string{"--", "bash", "-c", fmt.Sprintf("echo %s > /var/fdb/data/fdb.cluster && pkill fdbserver", cluster.Status.ConnectionString)}
+	execCommands := make([]exec.Cmd, 0, len(pods.Items))
+
+	for _, pod := range pods.Items {
+		args := append(baseArgs, pod.Name)
+		args = append(args, execArgs...)
+		execCommands = append(execCommands, exec.Cmd{
+			Path:   kubectlPath,
+			Args:   args,
+			Stdin:  os.Stdin,
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
+		})
+	}
+
+	return execCommands, nil
+}
+
+// updateIPsInConnectionString updates the connection string in the cluster
+// status by replacing old coordinator IPs with the latest IPs.
+func updateIPsInConnectionString(cluster *fdbtypes.FoundationDBCluster) error {
+	connectionString, err := fdbtypes.ParseConnectionString(cluster.Status.ConnectionString)
+	if err != nil {
+		return err
+	}
+	newCoordinators := make([]string, len(connectionString.Coordinators))
+	for coordinatorIndex, coordinator := range connectionString.Coordinators {
+		coordinatorAddress, err := fdbtypes.ParseProcessAddress(coordinator)
+		if err != nil {
+			return err
+		}
+		for _, processGroup := range cluster.Status.ProcessGroups {
+			for _, address := range processGroup.Addresses {
+				if address == coordinatorAddress.IPAddress.String() {
+					coordinatorAddress.IPAddress = net.ParseIP(processGroup.Addresses[len(processGroup.Addresses)-1])
+					newCoordinators[coordinatorIndex] = coordinatorAddress.String()
+				}
+			}
+		}
+		if newCoordinators[coordinatorIndex] == "" {
+			log.Printf("Could not find process for coordinator IP %s", coordinator)
+			newCoordinators[coordinatorIndex] = coordinator
+		}
+	}
+	connectionString.Coordinators = newCoordinators
+	cluster.Status.ConnectionString = connectionString.String()
+
+	return nil
+}
+
+func runFixCoordinatorIPs(kubeClient client.Client, cluster *fdbtypes.FoundationDBCluster, context string, namespace string, dryRun bool) error {
+	patch := client.MergeFrom(cluster.DeepCopy())
+	err := updateIPsInConnectionString(cluster)
+	if err != nil {
+		return err
+	}
+
+	logger := log.Default()
+	if dryRun {
+		logger.Printf("New connection string: %s", cluster.Status.ConnectionString)
+	}
+
+	commands, err := buildClusterFileUpdateCommands(cluster, kubeClient, context, namespace)
+	if err != nil {
+		return err
+	}
+	for _, command := range commands {
+		if dryRun {
+			logger.Printf("Update command: %s", strings.Join(command.Args, " "))
+		} else {
+			err := command.Run()
+			if err != nil {
+				logger.Print(err.Error())
+			}
+		}
+	}
+
+	if !dryRun {
+		err = kubeClient.Status().Patch(ctx.Background(), cluster, patch)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/kubectl-fdb/cmd/fix_coordinator_ips_test.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips_test.go
@@ -84,7 +84,7 @@ var _ = Describe("[plugin] fix-coordinator-ips command", func() {
 				kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&cluster, &podList).Build()
 				cluster.Status.ConnectionString = "test:test@127.0.0.1:4501"
 
-				commands, err := buildClusterFileUpdateCommands(&cluster, kubeClient, input.Context, namespace)
+				commands, err := buildClusterFileUpdateCommands(&cluster, kubeClient, input.Context, namespace, "/usr/local/bin/kubectl")
 
 				if input.ExpectedError != "" {
 					Expect(err).To(HaveOccurred())

--- a/kubectl-fdb/cmd/fix_coordinator_ips_test.go
+++ b/kubectl-fdb/cmd/fix_coordinator_ips_test.go
@@ -1,0 +1,233 @@
+/*
+ * fix_coordinator_ips_test.go
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	fdbtypes "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("[plugin] fix-coordinator-ips command", func() {
+	When("building cluster file update commands", func() {
+		clusterName := "test"
+		namespace := "test"
+
+		var cluster fdbtypes.FoundationDBCluster
+		var podList corev1.PodList
+
+		type testCase struct {
+			Context          string
+			ExpectedCommands [][]string
+			ExpectedError    string
+		}
+
+		BeforeEach(func() {
+			cluster = fdbtypes.FoundationDBCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: namespace,
+				},
+				Spec: fdbtypes.FoundationDBClusterSpec{
+					ProcessCounts: fdbtypes.ProcessCounts{
+						Storage: 1,
+					},
+				},
+			}
+
+			podList = corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "instance-1",
+							Namespace: namespace,
+							Labels: map[string]string{
+								fdbtypes.FDBProcessClassLabel: string(fdbtypes.ProcessClassStorage),
+								fdbtypes.FDBClusterLabel:      clusterName,
+							},
+						},
+					},
+				},
+			}
+		})
+
+		DescribeTable("should execute the provided command",
+			func(input testCase) {
+				scheme := runtime.NewScheme()
+				_ = clientgoscheme.AddToScheme(scheme)
+				_ = fdbtypes.AddToScheme(scheme)
+				kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&cluster, &podList).Build()
+				cluster.Status.ConnectionString = "test:test@127.0.0.1:4501"
+
+				commands, err := buildClusterFileUpdateCommands(&cluster, kubeClient, input.Context, namespace)
+
+				if input.ExpectedError != "" {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal(input.ExpectedError))
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(commands).To(HaveLen(len(input.ExpectedCommands)))
+					for index, command := range commands {
+						Expect(command.Args).To(Equal(input.ExpectedCommands[index]))
+					}
+				}
+			},
+			Entry("instance with valid pod",
+				testCase{
+					ExpectedCommands: [][]string{
+						{
+							"/usr/local/bin/kubectl",
+							"--namespace",
+							"test",
+							"exec",
+							"-it",
+							"-c",
+							"foundationdb",
+							"instance-1",
+							"--",
+							"bash",
+							"-c",
+							"echo test:test@127.0.0.1:4501 > /var/fdb/data/fdb.cluster && pkill fdbserver",
+						},
+					},
+				}),
+			Entry("instance with explicit context",
+				testCase{
+					Context: "remote-kc",
+					ExpectedCommands: [][]string{
+						{
+							"/usr/local/bin/kubectl",
+							"--namespace",
+							"test",
+							"--context",
+							"remote-kc",
+							"exec",
+							"-it",
+							"-c",
+							"foundationdb",
+							"instance-1",
+							"--",
+							"bash",
+							"-c",
+							"echo test:test@127.0.0.1:4501 > /var/fdb/data/fdb.cluster && pkill fdbserver",
+						},
+					},
+				},
+			),
+		)
+	})
+	When("updating the connection string", func() {
+		clusterName := "test"
+		namespace := "test"
+
+		var cluster fdbtypes.FoundationDBCluster
+
+		type testCase struct {
+			Context                  string
+			ExpectedConnectionString string
+			ExpectedError            string
+			AddressUpdates           map[string]string
+		}
+
+		BeforeEach(func() {
+			cluster = fdbtypes.FoundationDBCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: namespace,
+				},
+				Spec: fdbtypes.FoundationDBClusterSpec{
+					ProcessCounts: fdbtypes.ProcessCounts{
+						Storage: 1,
+					},
+				},
+				Status: fdbtypes.FoundationDBClusterStatus{
+					ConnectionString: "test:asdfkjh@127.0.0.1:4501,127.0.0.2:4501,127.0.0.3:4501",
+					ProcessGroups: []*fdbtypes.ProcessGroupStatus{
+						{ProcessGroupID: "storage-1", Addresses: []string{"127.0.0.1"}},
+						{ProcessGroupID: "storage-2", Addresses: []string{"127.0.0.2"}},
+						{ProcessGroupID: "storage-3", Addresses: []string{"127.0.0.3"}},
+						{ProcessGroupID: "storage-4", Addresses: []string{"127.0.0.4"}},
+						{ProcessGroupID: "storage-5", Addresses: []string{"127.0.0.5"}},
+					},
+				},
+			}
+		})
+
+		DescribeTable("should execute the provided command",
+			func(input testCase) {
+				scheme := runtime.NewScheme()
+				_ = clientgoscheme.AddToScheme(scheme)
+				_ = fdbtypes.AddToScheme(scheme)
+
+				for processGroupID, address := range input.AddressUpdates {
+					for _, processGroup := range cluster.Status.ProcessGroups {
+						if processGroup.ProcessGroupID == processGroupID {
+							if address == "" {
+								processGroup.Addresses = nil
+							} else {
+								processGroup.Addresses = append(processGroup.Addresses, address)
+							}
+						}
+					}
+				}
+				err := updateIPsInConnectionString(&cluster)
+
+				if input.ExpectedError != "" {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal(input.ExpectedError))
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(cluster.Status.ConnectionString).To(Equal(input.ExpectedConnectionString))
+				}
+			},
+			Entry("healthy cluster",
+				testCase{
+					ExpectedConnectionString: "test:asdfkjh@127.0.0.1:4501,127.0.0.2:4501,127.0.0.3:4501",
+				},
+			),
+			Entry("updated address",
+				testCase{
+					AddressUpdates: map[string]string{
+						"storage-1": "127.0.1.1",
+						"storage-2": "127.0.1.2",
+						"storage-5": "127.0.1.5",
+					},
+					ExpectedConnectionString: "test:asdfkjh@127.0.1.1:4501,127.0.1.2:4501,127.0.0.3:4501",
+				},
+			),
+			Entry("IP address with no process group",
+				testCase{
+					AddressUpdates: map[string]string{
+						"storage-1": "",
+					},
+					ExpectedConnectionString: "test:asdfkjh@127.0.0.1:4501,127.0.0.2:4501,127.0.0.3:4501",
+				},
+			),
+		)
+	})
+})

--- a/kubectl-fdb/cmd/root.go
+++ b/kubectl-fdb/cmd/root.go
@@ -78,6 +78,7 @@ func NewRootCmd(streams genericclioptions.IOStreams) *cobra.Command {
 		newRestartCmd(streams),
 		newAnalyzeCmd(streams),
 		newDeprecationCmd(streams),
+		newFixCoordinatorIPsCmd(streams),
 	)
 
 	return cmd


### PR DESCRIPTION
I believe this should bump the operator version to 0.41.1, but I'm not entirely sure, since I'm not used to working with forks. 

In any case, 0.41.1 seems to be pretty stable, as it didn't have any bug fixes for 17 days: https://github.com/FoundationDB/fdb-kubernetes-operator/tags
So it could be worth trying it out in test clusters