### PR TITLE
Recreating pods even if they are marked for removal, if the cluster is not fully available.

### DIFF
--- a/controllers/add_pods.go
+++ b/controllers/add_pods.go
@@ -24,9 +24,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
-
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
+	"github.com/FoundationDB/fdb-kubernetes-operator/pkg/podmanager"
 
 	fdbv1beta2 "github.com/FoundationDB/fdb-kubernetes-operator/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
@@ -63,9 +62,28 @@ func (a addPods) reconcile(ctx context.Context, r *FoundationDBClusterReconciler
 
 	podMap := internal.CreatePodMap(cluster, pods)
 
+	adminClient, err := r.DatabaseClientProvider.GetAdminClient(cluster, r)
+	if err != nil {
+		return &requeue{curError: err}
+	}
+	defer adminClient.Close()
+	hasDesiredFaultTolerance, err := internal.HasDesiredFaultTolerance(adminClient, cluster)
+	if err != nil {
+		return &requeue{curError: err}
+	}
+
 	for _, processGroup := range cluster.Status.ProcessGroups {
-		_, podExists := podMap[processGroup.ProcessGroupID]
-		if podExists || processGroup.IsMarkedForRemoval() {
+		if _, podExists := podMap[processGroup.ProcessGroupID]; podExists {
+			continue
+		}
+
+		// If this process group is marked for removal, we normally don't want to spin it back up
+		// again. However, in a downscaling scenario, it could be that this is a storage node that
+		// is still draining its data onto another one. Therefore, we only want to leave it off
+		// (by continue'ing) if the cluster is in a fault-tolerant state, meaning that all data
+		// is sufficiently replicated. (This is a simplifying overkill: it would be better to check
+		// if this node specifically is draining.)
+		if processGroup.IsMarkedForRemoval() && hasDesiredFaultTolerance {
 			continue
 		}
 

--- a/controllers/add_pods_test.go
+++ b/controllers/add_pods_test.go
@@ -22,6 +22,7 @@ package controllers
 
 import (
 	"context"
+	"k8s.io/utils/pointer"
 	"sort"
 
 	"github.com/FoundationDB/fdb-kubernetes-operator/internal"
@@ -38,6 +39,7 @@ var _ = Describe("add_pods", func() {
 	var requeue *requeue
 	var initialPods *corev1.PodList
 	var newPods *corev1.PodList
+	var adminClient *mockAdminClient
 
 	BeforeEach(func() {
 		cluster = internal.CreateDefaultCluster()
@@ -57,6 +59,9 @@ var _ = Describe("add_pods", func() {
 
 		initialPods = &corev1.PodList{}
 		err = k8sClient.List(context.TODO(), initialPods)
+		Expect(err).NotTo(HaveOccurred())
+
+		adminClient, err = newMockAdminClientUncast(cluster, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -94,26 +99,86 @@ var _ = Describe("add_pods", func() {
 		})
 
 		It("should create an extra pod", func() {
-			Expect(newPods.Items).To(HaveLen(len(initialPods.Items) + 1))
-			lastPod := newPods.Items[len(newPods.Items)-1]
-			Expect(lastPod.Name).To(Equal("operator-test-1-storage-9"))
-			Expect(lastPod.Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("storage-9"))
-			Expect(lastPod.Labels[fdbv1beta2.FDBProcessClassLabel]).To(Equal("storage"))
-			Expect(lastPod.OwnerReferences).To(Equal(internal.BuildOwnerReference(cluster.TypeMeta, cluster.ObjectMeta)))
+			expectNewPodToHaveBeenCreated(initialPods, newPods, cluster)
 		})
 
-		Context("when the process group is being removed", func() {
+		When("the process group is being removed", func() {
 			BeforeEach(func() {
 				cluster.Status.ProcessGroups[len(cluster.Status.ProcessGroups)-1].MarkForRemoval()
 			})
 
-			It("should not requeue", func() {
-				Expect(requeue).To(BeNil())
+			When("the cluster is fully replicated", func() {
+				It("should not requeue", func() {
+					Expect(requeue).To(BeNil())
+				})
+
+				It("should not create any pods", func() {
+					Expect(newPods.Items).To(HaveLen(len(initialPods.Items)))
+				})
 			})
 
-			It("should not create any pods", func() {
-				Expect(newPods.Items).To(HaveLen(len(initialPods.Items)))
+			// The following scenarios are regression tests for a bug where pods marked for removal
+			// would not be recreated. The reason they actually do need to be recreated is that they
+			// might contain data that needs to be drained to other storage nodes, so they should
+			// cease to exist only when they have been successfully drained.
+
+			When("the cluster has degraded availability fault tolerance", func() {
+				BeforeEach(func() {
+					adminClient.maxZoneFailuresWithoutLosingAvailability = pointer.Int(0)
+				})
+
+				It("should not requeue", func() {
+					Expect(requeue).To(BeNil())
+				})
+
+				It("should create an extra pod", func() {
+					expectNewPodToHaveBeenCreated(initialPods, newPods, cluster)
+				})
+			})
+
+			When("the cluster has degraded data fault tolerance", func() {
+				BeforeEach(func() {
+					adminClient.maxZoneFailuresWithoutLosingData = pointer.Int(0)
+				})
+
+				It("should not requeue", func() {
+					Expect(requeue).To(BeNil())
+				})
+
+				It("should create an extra pod", func() {
+					expectNewPodToHaveBeenCreated(initialPods, newPods, cluster)
+				})
+			})
+
+			When("the cluster is not available", func() {
+				BeforeEach(func() {
+					adminClient.frozenStatus = &fdbv1beta2.FoundationDBStatus{
+						Client: fdbv1beta2.FoundationDBStatusLocalClientInfo{
+							DatabaseStatus: fdbv1beta2.FoundationDBStatusClientDBStatus{
+								Available: false,
+							},
+						},
+					}
+				})
+
+				It("should not requeue", func() {
+					Expect(requeue).To(BeNil())
+				})
+
+				It("should create an extra pod", func() {
+					expectNewPodToHaveBeenCreated(initialPods, newPods, cluster)
+				})
 			})
 		})
 	})
 })
+
+func expectNewPodToHaveBeenCreated(initialPods *corev1.PodList, newPods *corev1.PodList, cluster *fdbv1beta2.FoundationDBCluster) {
+	Expect(newPods.Items).To(HaveLen(len(initialPods.Items) + 1))
+	lastPod := newPods.Items[len(newPods.Items)-1]
+	Expect(lastPod.Name).To(Equal("operator-test-1-storage-9"))
+	Expect(lastPod.Labels[fdbv1beta2.FDBProcessGroupIDLabel]).To(Equal("storage-9"))
+	Expect(lastPod.Labels[fdbv1beta2.FDBProcessClassLabel]).To(Equal("storage"))
+	Expect(lastPod.OwnerReferences).To(Equal(internal.BuildOwnerReference(cluster.TypeMeta, cluster.ObjectMeta)))
+	// TODO: Should we assert something here about persistent volume claims?
+}


### PR DESCRIPTION
This is a bit of overkill, since it might also bring back nodes that were actually fully drained, but it seems like a good first step.

TODO: Fill out the below template before submitting an upstream PR.

# Description

*Please include a summary of the change and which issue is addressed. If this change resolves an issue, please include the issue number in the description.*

## Type of change

*Please select one of the options below.*

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation
- Other

# Discussion

*Are there any design details that you would like to discuss further?*

# Testing

*Please describe the tests that you ran to verify your changes. Unit tests?
Manual testing?*

*Do we need to perform additional testing once this is merged, or perform in a larger testing environment?*

# Documentation

*Did you update relevant documentation within this repository?*

*If this change is adding new functionality, do we need to describe it in our user manual?*

*If this change is adding or removing subreconcilers, have we updated the core technical design doc to reflect that?*

*If this change is adding new safety checks or new potential failure modes, have we documented and how to debug potential issues?*

# Follow-up

*Are there any follow-up issues that we should pursue in the future?*

*Does this introduce new defaults that we should re-evaluate in the future?*
